### PR TITLE
feat: add new page "blueprint interaction" to query blueprints in demo app

### DIFF
--- a/app/data/DemoApplicationDataSource/models/CarPackage/Car.json
+++ b/app/data/DemoApplicationDataSource/models/CarPackage/Car.json
@@ -1,0 +1,20 @@
+{
+  "name": "Car",
+  "type": "system/SIMOS/Blueprint",
+  "extends": ["system/SIMOS/NamedEntity"],
+  "description": "",
+  "attributes": [
+    {
+      "name": "color",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "wheels",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "DemoApplicationDataSource/models/CarPacakge/Wheel",
+      "dimensions": "*"
+    }
+  ],
+  "uiRecipes": []
+}

--- a/app/data/DemoApplicationDataSource/models/CarPackage/Wheel.json
+++ b/app/data/DemoApplicationDataSource/models/CarPackage/Wheel.json
@@ -1,0 +1,20 @@
+{
+  "type": "system/SIMOS/Blueprint",
+  "name": "Wheel",
+  "attributes": [
+    {
+      "name": "brand",
+      "optional": false,
+      "attributeType": "string",
+      "type": "system/SIMOS/BlueprintAttribute"
+    },
+    {
+      "name": "dimensions",
+      "attributeType": "string",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "label": "string"
+    }
+  ],
+  "storageRecipes": [],
+  "uiRecipes": []
+}

--- a/src/plugins/demo-app/Routes.tsx
+++ b/src/plugins/demo-app/Routes.tsx
@@ -1,15 +1,20 @@
 import { TRoute } from '@development-framework/dm-core'
 import {Overview} from "./pages/Overview";
 import {Jobs} from "./pages/JobExample";
+import {BlueprintInteraction} from "./pages/BlueprintInteraction";
 
 const Routes: Array<TRoute> = [
-      {
+  {
     path: '/jobs',
     content: Jobs,
   },
   {
     path: '/',
     content: Overview,
+  },
+  {
+    path: '/blueprint-interaction',
+    content: BlueprintInteraction,
   },
 
 ]

--- a/src/plugins/demo-app/layout/Menu.tsx
+++ b/src/plugins/demo-app/layout/Menu.tsx
@@ -32,6 +32,9 @@ const AppMenu = (): JSX.Element => {
         <Menu.Item key={"2"}>
           <Link to={{ pathname: 'jobs' }}>Job example</Link>
         </Menu.Item>
+        <Menu.Item key={"3"}>
+          <Link to={{ pathname: 'blueprint-interaction' }}>Blueprint interaction</Link>
+        </Menu.Item>
       </Menu>
     </Sider>
   )

--- a/src/plugins/demo-app/pages/BlueprintInteraction.tsx
+++ b/src/plugins/demo-app/pages/BlueprintInteraction.tsx
@@ -1,0 +1,37 @@
+import {
+  AuthContext,
+  DmssAPI,
+    JsonView
+} from '@development-framework/dm-core'
+import React, {useContext, useEffect, useState} from 'react'
+import {SingleSelect} from '@equinor/eds-core-react'
+import {AxiosResponse} from "axios";
+
+export const BlueprintInteraction = () => {
+  const packageName = "CarPackage"
+  const dataSource = 'DemoApplicationDataSource'
+  const { token } = useContext(AuthContext)
+  const dmssApi = new DmssAPI(token)
+  const [blueprints, setBlueprints] = useState<any[]>([])
+  const [selectedBlueprint, setSelectedBlueprint] = useState<object>({})
+
+  useEffect(() => {
+      fetchBlueprintsFromPackage(packageName)
+    }, [])
+
+  const fetchBlueprintsFromPackage = (pacakgeName: string) => {
+      dmssApi.documentGetByPath({dataSourceId: dataSource, path: `models/${pacakgeName}`})
+          .then((response: AxiosResponse<any> ) => {
+              setBlueprints(response.data.content)
+          })
+  }
+
+ return <div>
+        <p>
+            Select a blueprint inside the package: {packageName}
+        </p>
+        <SingleSelect items={blueprints.map((blueprint) => blueprint.name )} handleSelectedItemChange={(e) => setSelectedBlueprint(blueprints.find((blueprint, index) => blueprints[index].name === e.selectedItem ))} label={"Choose a blueprint"} />
+        {Object.keys(selectedBlueprint).length > 0 && <JsonView style={{paddingTop: "20px"}} data={selectedBlueprint} />}
+    </div>
+
+}


### PR DESCRIPTION
add an example to demo app: how to fetch blueprints from dmss 

closes #21 


![image](https://user-images.githubusercontent.com/69512295/200285339-57748ebc-50eb-45ed-9d90-6a3812ba8639.png)
