### PR TITLE
feat: create entity of a selected blueprint

### DIFF
--- a/src/plugins/demo-app/pages/BlueprintInteraction.tsx
+++ b/src/plugins/demo-app/pages/BlueprintInteraction.tsx
@@ -1,19 +1,27 @@
-import { AuthContext, DmssAPI, JsonView } from '@development-framework/dm-core'
+import {
+  AuthContext,
+  DmssAPI,
+  JsonView,
+  NewEntityButton,
+  TReference,
+} from '@development-framework/dm-core'
 import React, { useContext, useEffect, useState } from 'react'
 import { SingleSelect } from '@equinor/eds-core-react'
 import { AxiosResponse } from 'axios'
 
 export const BlueprintInteraction = () => {
+  const dataSourceName = 'DemoApplicationDataSource'
   const packageName = 'CarPackage'
   const { token } = useContext(AuthContext)
   const dmssApi = new DmssAPI(token)
   const [blueprints, setBlueprints] = useState<any[]>([])
-  const [selectedBlueprint, setSelectedBlueprint] = useState<object>({})
+  const [selectedBlueprint, setSelectedBlueprint] = useState<any>({})
+  const [entity, setEntity] = useState<any>({})
 
   useEffect(() => {
     dmssApi
       .documentGetByPath({
-        absolutePath: `sys://DemoApplicationDataSource/models/${packageName}`,
+        absolutePath: `sys://${dataSourceName}/models/${packageName}`,
       })
       .then((response: AxiosResponse<any>) => {
         setBlueprints(response.data.content)
@@ -35,7 +43,25 @@ export const BlueprintInteraction = () => {
         label={'Choose a blueprint'}
       />
       {Object.keys(selectedBlueprint).length > 0 && (
-        <JsonView style={{ paddingTop: '20px' }} data={selectedBlueprint} />
+        <>
+          <JsonView style={{ paddingTop: '20px' }} data={selectedBlueprint} />
+          <NewEntityButton
+            type={`sys://${dataSourceName}/models/${packageName}/${selectedBlueprint.name}`}
+            defaultDestination={`${dataSourceName}/instances`}
+            setReference={(createdEntity: TReference) =>
+              dmssApi
+                .documentGetById({
+                  idReference: `${dataSourceName}/${createdEntity._id}`,
+                })
+                .then((response) => {
+                  setEntity(response.data)
+                })
+            }
+          />
+        </>
+      )}
+      {Object.keys(entity).length > 0 && (
+        <JsonView style={{ paddingTop: '20px' }} data={entity} />
       )}
     </div>
   )


### PR DESCRIPTION
## What does this pull request change?

* Uses `NewEntityButton` to create new entities

## Why is this pull request needed?

* Add an example of how to create new entities after picking blueprints

## Issues related to this change
