### PR TITLE
Feature: support for `dm entity import` (added `_meta_`)

### DIFF
--- a/app/data/DemoApplicationDataSource/instances/demoApplication.json
+++ b/app/data/DemoApplicationDataSource/instances/demoApplication.json
@@ -3,5 +3,23 @@
   "type": "TEST-MODELS:DemoApplication",
   "name": "demo-app",
   "label": "Demo App",
-  "dataSources": ["DemoApplicationDataSource"]
+  "dataSources": ["DemoApplicationDataSource"],
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      },
+      {
+        "alias": "TEST-MODELS",
+        "address": "DemoApplicationDataSource/models",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      }
+    ]
+  }
 }

--- a/app/data/DemoApplicationDataSource/models/DemoApplication.json
+++ b/app/data/DemoApplicationDataSource/models/DemoApplication.json
@@ -17,5 +17,17 @@
       "dimensions": "*",
       "optional": false
     }
-  ]
+  ],
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "dmss"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## What does this pull request change?
- Adds `_meta_` to the documents in `app/`, so that single entities may be imported using `dm entity import`

## Why is this pull request needed?
- To facilitate for the new `dm entity import` function in `dm-cli`

## Issues related to this change:
- Dependent of https://github.com/equinor/dm-cli/pull/48
