### PR TITLE
fix: bug with create new entity in BlueprintInteraction page

### DIFF
--- a/app/data/DemoApplicationDataSource/models/CarPackage/Car.json
+++ b/app/data/DemoApplicationDataSource/models/CarPackage/Car.json
@@ -1,7 +1,9 @@
 {
   "name": "Car",
   "type": "CORE:Blueprint",
-  "extends": ["CORE:NamedEntity"],
+  "extends": [
+    "CORE:NamedEntity"
+  ],
   "description": "",
   "attributes": [
     {
@@ -12,7 +14,7 @@
     {
       "name": "wheels",
       "type": "CORE:BlueprintAttribute",
-      "attributeType": "/CarPackage/Wheel",
+      "attributeType": "/models/CarPackage/Wheel",
       "dimensions": "*"
     }
   ]

--- a/src/plugins/demo-app/pages/BlueprintInteraction.tsx
+++ b/src/plugins/demo-app/pages/BlueprintInteraction.tsx
@@ -34,19 +34,22 @@ export const BlueprintInteraction = () => {
       <p>Select a blueprint inside the package: {packageName}</p>
       <SingleSelect
         items={blueprints.map((blueprint) => blueprint.name)}
-        handleSelectedItemChange={(e) =>
+        handleSelectedItemChange={(e) => {
           setSelectedBlueprint(
             blueprints.find(
               (blueprint, index) => blueprints[index].name === e.selectedItem
             )
           )
-        }
+          setEntity({})
+        }}
         label={'Choose a blueprint'}
       />
       {Object.keys(selectedBlueprint).length > 0 && (
         <>
           <br />
+          <h2 style={{ paddingTop: '20px' }}>Blueprint:</h2>
           <JsonView style={jsonContainer} data={selectedBlueprint} />
+          <h2>Create new entity</h2>
           <NewEntityButton
             type={`dmss://${dataSourceName}/models/${packageName}/${selectedBlueprint.name}`}
             defaultDestination={`${dataSourceName}/instances`}


### PR DESCRIPTION
## What does this pull request change?
fix bug in blueprint interaction - create new entity is now working again.
## Why is this pull request needed?

## Issues related to this change:
