### PR TITLE
ci: fix npm publish

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -16,7 +16,7 @@ jobs:
         id: release
         with:
           release-type: node
-          release-as: 0.1.0 # Temp. Remove after initial release-please PR has been merged
+          # release-as: 1.0.0 This config is needed for first stable release
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
           package-name: '@development-framework/create-dm-app'

--- a/.github/workflows/on-push-main.yaml
+++ b/.github/workflows/on-push-main.yaml
@@ -21,3 +21,5 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/publish-to-registry.yaml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-to-registry.yaml
+++ b/.github/workflows/publish-to-registry.yaml
@@ -2,6 +2,9 @@ name: 'Publish to npm registry'
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 jobs:
   publish-packages:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,22 +4,20 @@ on:
   # Workflow call is used for called from another workflow
   workflow_call:
 
-
-
 jobs:
   test-web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Install Pre-commit
         run: pip install pre-commit
+
       - name: Run pre-commit
         run: pre-commit run --all-files
 
-      - name: "Install web packages"
-        run: |
-          yarn install
+      - name: 'Install web packages'
+        run: npm install
 
-      - name: "Test for typescript errors"
-        run: yarn tsc
+      - name: 'Test for typescript errors'
+        run: npx tsc


### PR DESCRIPTION
## What does this pull request change?

- Pass secret to reusable workflow
- Remove hardcoded version number
- Fix bug in ci tests

## Why is this pull request needed?

Release to npm failed

## Issues related to this change:

Refs #63 
