### PR TITLE
chore: improve cli command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { execSync } = require('child_process')
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJson = require('../package.json')
 
 const runCommand = (command) => {
   try {
@@ -24,17 +26,12 @@ function sanitize_string(command) {
 }
 
 const repoName = sanitize_string(process.argv[2])
-const gitCloneCommand = `git clone --single-branch https://github.com/equinor/create-dm-app ${repoName}`
-const gitCheckoutCommand = `cd ${repoName} && LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1)) && git checkout "$LATEST_TAG"`
+const gitCloneCommand = `git clone --depth 1 --branch v${packageJson.version} https://github.com/equinor/create-dm-app ${repoName}`
 const installDepsCommand = `cd ${repoName} && npm install`
 
-console.log(`Cloning the repository with name ${repoName}`)
+console.log(`Cloning version v${packageJson.version} into ${repoName}`)
 const cloned = runCommand(gitCloneCommand)
 if (!cloned) process.exit(-1)
-
-console.log(`Checking out latest stable version...`)
-const checkedOut = runCommand(gitCheckoutCommand)
-if (!checkedOut) process.exit(-1)
 
 console.log(`Installing dependencies for ${repoName}`)
 const installedDeps = runCommand(installDepsCommand)
@@ -44,6 +41,7 @@ console.log('Cleaning up...')
 runCommand(`rm -rf ${repoName}/bin`)
 runCommand(`rm -rf ${repoName}/.git`)
 runCommand(`rm -rf ${repoName}/.github`)
+runCommand(`rm -rf ${repoName}/CHANGELOG.md`)
 
 console.log(
   'Congratulations! You are ready. Follow the following commands to start'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.1",
   "bin": "./bin/cli.js",
   "license": "MIT",
+  "files": [
+    "bin"
+  ],
   "dependencies": {
     "@development-framework/dm-core": "^1.0.37",
     "@development-framework/yaml-view": "^1.0.4",


### PR DESCRIPTION
## What does this pull request change?

- Running `npx @development-framework/create-dm-app@<my-version> my-app` now results in you getting a clone of the git repo at version <my-version>. 
- CHANGELOG.md is removed from the clone
- Only package.json, readme.md and bin/cli.js is uploaded to npm

Note: The issue suggested I copy the files from npm instead of cloning from git. I did not find a way to do that, so I did this instead.

## Why is this pull request needed?

The npm package is cluttered with unused files. Also, running the npx script with an older version still gives you a copy of the newest tag

## Issues related to this change:

Closes #70
