### PR TITLE
refactor: get data sources to show from application instead of env

### DIFF
--- a/.env
+++ b/.env
@@ -6,9 +6,6 @@ JOB_API_TAG=v1.0.6
 VITE_APPLICATION_ID=4483c9b0-d505-46c9-a157-94c79f4d7a6a
 VITE_DATA_SOURCE=DemoApplicationDataSource
 
-# Control which data sources to be visible inside the explorer plugin
-VITE_VISIBLE_DATA_SOURCES=DemoApplicationDataSource
-
 # Azure Auth
 VITE_AUTH_ENABLED=0
 VITE_REDIRECT_URI=http://localhost:3000/

--- a/app/data/DemoApplicationDataSource/DemoApplication/entities/demoApplication.json
+++ b/app/data/DemoApplicationDataSource/DemoApplication/entities/demoApplication.json
@@ -4,6 +4,8 @@
   "type": "../blueprints/DemoApplication",
   "label": "Demo App",
   "dataSources": [
-    "DemoApplicationDataSource"
+    "DemoApplicationDataSource",
+    "system",
+    "WorkflowDS"
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,9 +27,7 @@ function App() {
   }
 
   return (
-    <FSTreeProvider
-      visibleDataSources={import.meta.env.VITE_VISIBLE_DATA_SOURCES.split(',')}
-    >
+    <FSTreeProvider visibleDataSources={application?.dataSources}>
       <EntityView
         idReference={`${import.meta.env.VITE_DATA_SOURCE}/$${application?._id}`}
         type={application?.type}


### PR DESCRIPTION
## What does this pull request change?

* Get data sources to show in explorer from application entity instead of env file

## Why is this pull request needed?


## Issues related to this change:
