### PR TITLE
fix: correct dmss urls

### DIFF
--- a/.env
+++ b/.env
@@ -17,4 +17,4 @@ VITE_CLIENT_ID= # Find tenant ID through the Azure portal under Azure Active Dir
 VITE_TENANT_ID= # Find tenant ID through the Azure portal under Azure Active Directory service. Select properties and under scroll down to the Tenant ID field.
 
 # Control what DMSS instance to use
-VITE_DMSS_URL=http://localhost:5000
+VITE_DMSS_URL=http://localhost:5002

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: maf
       SECRET_KEY: sg9aeUM5i1JO4gNN8fQadokJa3_gXQMLBjSGGYcfscs= # Don't reuse this in production...
     ports:
-      - "5051:5000"
+      - "5002:5000"
     depends_on:
       - db
 

--- a/reset-app.sh
+++ b/reset-app.sh
@@ -25,7 +25,7 @@ fi
 
 eval $compose run --rm dmss reset-app
 eval $compose run --rm job-api dm -u http://dmss:5000 reset ../app
-dm --url http://localhost:5051 import-plugin-blueprints node_modules/@development-framework/dm-core-plugins
-dm --url http://localhost:5051 reset app --$VALIDATION_FLAG
+dm --url http://localhost:5002 import-plugin-blueprints node_modules/@development-framework/dm-core-plugins
+dm --url http://localhost:5002 reset app --$VALIDATION_FLAG
 echo "Creating lookup table"
-dm --url http://localhost:5051 create-lookup DemoApp DemoApplicationDataSource/DemoApplication/recipes
+dm --url http://localhost:5002 create-lookup DemoApp DemoApplicationDataSource/DemoApplication/recipes


### PR DESCRIPTION
## What does this pull request change?

* The port specified in the docker-compose file does not match what is in the `reset-app.sh` and `.env` file.

> **NOTE** The `reset-app.sh` script need to use the container service name "dmss:5000".

## Why is this pull request needed?

## Issues related to this change:
